### PR TITLE
remove jQuery.noConflict();

### DIFF
--- a/src/Resources/contao/templates/modules/mod_ticker.html5
+++ b/src/Resources/contao/templates/modules/mod_ticker.html5
@@ -11,7 +11,6 @@
   <div id="tx_<?= $this->ticker['id'] ?>" class="tickertext"></div>
 </section>
 <script>
-jQuery.noConflict();
 (function($) {
   $(document).ready(function () {
     var qtx = Telex.widget( "tx_<?= $this->ticker['id'] ?>", 


### PR DESCRIPTION
This line should not be necessary. You only need this in cases where you want to use multiple versions of jQuery. In all other cases a function wrapper, which you already use, is sufficient.